### PR TITLE
Fix UnboundLocalError in diagnostics method when using pre-computed indicators

### DIFF
--- a/src/lf2i/diagnostics/coverage_probability.py
+++ b/src/lf2i/diagnostics/coverage_probability.py
@@ -269,6 +269,7 @@ def compute_indicators_posterior(
         out = list(zip(*Parallel(n_jobs=n_jobs)(delayed(single_hpd_region)(idx) for idx in it)))
     credible_regions, indicators = out[0], np.array(out[1])
     
+    # TODO: handle additional cases where sizes, indicators, and credible_regions can be passed
     if return_credible_regions:
         return indicators, credible_regions
     else:

--- a/src/lf2i/inference/lf2i.py
+++ b/src/lf2i/inference/lf2i.py
@@ -306,6 +306,9 @@ class LF2I:
         ValueError
             If `region_type` is not among those supported and `indicators is None`
         """
+        # TODO: Allow for `sizes` to be passed to diagnostics methods and remove this statement
+        sizes = None
+
         if region_type == 'lf2i':
             assert calibration_method in ['critical-values', 'p-values']
         self.test_statistic.verbose = verbose  # lf2i verbosity takes precedence
@@ -390,7 +393,8 @@ class LF2I:
             param_dim=parameters.shape[1] if parameters.ndim > 1 else 1,
             new_parameters=new_parameters
         )
-        if region_type == 'posterior':
+
+        if region_type == 'posterior' and sizes is not None:
             return diagnostics_estimator, out_parameters, mean_proba, upper_proba, lower_proba, sizes
         else:
             return diagnostics_estimator, out_parameters, mean_proba, upper_proba, lower_proba


### PR DESCRIPTION
## Summary
Fixes a bug where the `diagnostics` method in `LF2I` class throws an `UnboundLocalError` when called with `region_type="posterior"` and pre-computed indicators.

## Problem
The `sizes` variable was only initialized when indicators were computed internally, but was always returned for posterior region types, causing an `UnboundLocalError` when users provided pre-computed indicators.

## Changes
- Initialize `sizes = None` at the beginning of the `diagnostics` method
- Modified return logic to only include `sizes` in the return tuple when it was actually computed
- Added TODO comments for later refactoring of code

Closes #7 